### PR TITLE
Task/ep 3086 update pg version

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -10,7 +10,7 @@ build:
   - image: 280296955917.dkr.ecr.us-east-2.amazonaws.com/postgis
     kaniko:
       cache: {}
-      dockerfile: 15-3.4/Dockerfile
+      dockerfile: 17-3.5/Dockerfile
       useNewRun: false
       reproducible: true
       snapshotMode: redo


### PR DESCRIPTION
I updated rail's docker-compose.yml to use image: 280296955917.dkr.ecr.us-east-2.amazonaws.com/postgis:2025-05-02_22-15-00

# Test

Test (and approve) https://github.com/fulcrumapp/fulcrum/pull/9673
If that's good, this is good.